### PR TITLE
fix add-zsh-hook not found

### DIFF
--- a/almostontop.plugin.zsh
+++ b/almostontop.plugin.zsh
@@ -13,7 +13,9 @@ function almostontop_preexec
   fi
 }
 
-add-zsh-hook preexec almostontop_preexec
+if [ -f "/usr/share/zsh/functions/Misc/add-zsh-hook" ] ; then
+        autoload -U add-zsh-hook && add-zsh-hook preexec almostontop_preexec
+fi
 
 function almostontop
 {


### PR DESCRIPTION
I had the following error

``` bash
.oh-my-zsh/custom/plugins/almostontop/almostontop.plugin.zsh:16: command not found: add-zsh-hook
```

After adding the test, everything is fine now.
