### PR TITLE
completions added

### DIFF
--- a/_almostontop
+++ b/_almostontop
@@ -1,0 +1,16 @@
+#compdef almostontop
+
+_almostontop_cmds() {
+  local commands; commands=(
+    'on:Enables almostontop plugin'
+    'off:Disables almostontop plugin'
+    'toggle:Toggles almostontop plugin'
+  )
+  _describe -t commands 'almostontop command' commands "$@"
+}
+
+_almostontop() {
+  _arguments -C '1: :_almostontop_cmds'
+}
+
+_almostontop "$@"

--- a/almostontop.plugin.zsh
+++ b/almostontop.plugin.zsh
@@ -4,12 +4,16 @@ else
   ALMOSONTOP=true
 fi
 
+if [ "$ALMOSTONTOP_COLOR" = "" ]; then
+  ALMOSTONTOP_COLOR="green"
+fi
+
 function almostontop_preexec
 {
   if [ "x$ALMOSONTOP" = "xtrue" ]; then
     clear
     # print PROMPT and command itself on the top
-    echo "$(print -P $prompt)$fg[green]${(z)1}$reset_color"
+    echo "$(print -P $prompt)$fg[$ALMOSTONTOP_COLOR]${(z)1}$reset_color"
   fi
 }
 


### PR DESCRIPTION
Simple enough but really helps with discovery of the commands. The completions should just work, but I've only tested locally using [zplug](https://github.com/b4b4r07/zplug) with `zsh` 5.2 on OS X, I'm happy to test and fix any issues with other plugin managers if they occur.
